### PR TITLE
Added index conflict ignore flag to mutations and transactions

### DIFF
--- a/lib/dgraph.js
+++ b/lib/dgraph.js
@@ -63,12 +63,13 @@ class DgraphClient {
     return parsed;
   }
 
-  async mutate(mutation, commit = true, startTs) {
+  async mutate(mutation, commit = true, startTs, conflict = false) {
     const mutationRequest = new _protos2.default.Mutation();
     if (mutation.set) mutationRequest.set_nquads = Buffer.from(mutation.set, 'utf8');
     if (mutation.del) mutationRequest.del_nquads = Buffer.from(mutation.del, 'utf8');
     if (startTs) mutationRequest.start_ts = startTs;
     mutationRequest.commit_now = commit;
+    mutationRequest.ignore_index_conflict = conflict;
     if (this.config.debug) console.log(`Mutation request: \n${JSON.stringify(mutation, null, 2)}`);
     const resp = await this._mutate(mutationRequest);
     const parsed = {

--- a/lib/protos.js
+++ b/lib/protos.js
@@ -17,5 +17,5 @@ var _path2 = _interopRequireDefault(_path);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-const p1 = _grpc2.default.load(_path2.default.join(__dirname, '/../protos/task.proto'));
-exports.default = _extends({}, p1.protos);
+const p1 = _grpc2.default.load(_path2.default.join(__dirname, '/../protos/api.proto'));
+exports.default = _extends({}, p1.api);

--- a/src/__tests__/dgraph.spec.js
+++ b/src/__tests__/dgraph.spec.js
@@ -43,6 +43,17 @@ describe('dgraph', () => {
     })
   })
 
+  it('should commit mutation with index', async () => {
+    const resp = await client.mutate({
+      set: '<_:bob> <name> "Bob" .',
+    }, true, undefined, true)
+    const { bob } = resp.data.uids
+    const query = await client.query(queryById(bob))
+    expect(query.data.q[0]).toEqual({
+      name: 'Bob',
+    })
+  })
+
   it('should drop the DB', async () => {
     const resp = await createBob()
     await client.dropAll()

--- a/src/dgraph.js
+++ b/src/dgraph.js
@@ -12,7 +12,7 @@ export default class DgraphClient {
       debug: false,
       ...userConfig,
     }
-    
+
     // Create gprc client into Dgraph
     const d = new protos.Dgraph(
       config.url,
@@ -44,12 +44,13 @@ export default class DgraphClient {
     return parsed
   }
 
-  async mutate (mutation, commit = true, startTs) {
+  async mutate (mutation, commit = true, startTs, conflict = false) {
     const mutationRequest = new protos.Mutation()
     if (mutation.set) mutationRequest.set_nquads = Buffer.from(mutation.set, 'utf8')
     if (mutation.del) mutationRequest.del_nquads = Buffer.from(mutation.del, 'utf8')
     if (startTs) mutationRequest.start_ts = startTs
     mutationRequest.commit_now = commit
+    mutationRequest.ignore_index_conflict = conflict
     if (this.config.debug) console.log(`Mutation request: \n${JSON.stringify(mutation, null, 2)}`)
     const resp = await this._mutate(mutationRequest)
     const parsed = {

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -7,6 +7,7 @@ export default class Transaction {
   constructor (client) {
     this.client = client
     this.startTs = null
+    this.ignoreIndexConflict = false
     this.linRead = client.linRead
     this.keys = []
   }
@@ -18,7 +19,7 @@ export default class Transaction {
   }
 
   async mutate (mutation) {
-    const resp = await this.client.mutate(mutation, false, this.startTs)
+    const resp = await this.client.mutate(mutation, false, this.startTs, this.ignoreIndexConflict)
     this.updateContext(resp.context)
     return resp
   }


### PR DESCRIPTION
Ran into an issue where I needed the index conflict ignoring flag. I've adapted it very roughly by modifying `.mutate()` and the `Transactions` class. Also added a basic test to see if the flag is passed, although no easy way to test if the flag was sent successfully.

Also note that there was a pre-existing test fail related to startTs: Transactions › Managing context › should send startTs on mutations after first request. I don't believe my patches caused that and unfortunately I couldn't dive into it further.